### PR TITLE
fix: remove debug print

### DIFF
--- a/core/src/main/java/xyz/gianlu/librespot/handler/ArtistInsightsHandler.java
+++ b/core/src/main/java/xyz/gianlu/librespot/handler/ArtistInsightsHandler.java
@@ -56,7 +56,6 @@ public class ArtistInsightsHandler implements HttpHandler {
                     } else {
                         try {
                             MercuryRequests.GenericJsonWrapper resp = this.mercuryClient.sendSync(MercuryRequests.getArtistInsights(artistId)); // Get artist insights with artistId
-                            System.out.println(resp.obj);
 
                             statusCode = 200;
                             res.put("success", true);


### PR DESCRIPTION
# Modified
- Remove a print when artistInsights is called and the result is not cached